### PR TITLE
feat/auto-deploy : PyPIへの自動デプロイを設定

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,6 +5,11 @@ on:
     types: [closed]
     branches:
       - main
+  release:
+    types: [published]
+
+permissions:
+  contents: read
 
 jobs:
   deploy:
@@ -14,9 +19,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Rye
+        shell: bash
         run: |
           curl -sSf https://rye.astral.sh/get | bash
           echo 'source "$HOME/.rye/env"' >> ~/.bashrc


### PR DESCRIPTION
# 対応内容
developブランチをmainブランチにマージした際にPyPIに自動的にmain内容をデプロイするようにGitHubのworkflowを追加。ただし、未テスト。