### PR TITLE
fix : generateコマンドでエラーが出てしまう原因を特定し修正

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AtCoderStudyBooster"
-version = "0.23"
+version = "0.24"
 description = "A tool to download and manage AtCoder problems."
 authors = [
     { name = "yuta6", email = "46110512+yuta6@users.noreply.github.com" }
@@ -10,7 +10,7 @@ dependencies = [
     "fire",
     "requests",
     "tiktoken",
-    "yfinance",
+    "yfinance==0.2.41",
     "types-requests>=2.32.0.20240712",
     "types-beautifulsoup4>=4.12.0.20240511",
     "markdownify>=0.13.1",


### PR DESCRIPTION
・generateコマンド実行時にyfinanceが為替レートを取得する処理でエラーが発生していた。yfinanceのバージョンを最新バージョンの0.2.43でのみエラーが起きていたので0.2.41に固定することで対応した