### PR TITLE
refactor : parse.pyをクラスで整理した, それにともない依存している各種コマンドを修正した

### DIFF
--- a/atcdr/generate.py
+++ b/atcdr/generate.py
@@ -10,7 +10,6 @@ from atcdr.test import (
     LabeledTestCaseResult,
     ResultStatus,
     TestInformation,
-    create_testcases_from_html,
     judge_code_from,
 )
 from atcdr.util.execute import execute_files
@@ -22,7 +21,7 @@ from atcdr.util.filetype import (
     str2lang,
 )
 from atcdr.util.gpt import ChatGPT, set_api_key
-from atcdr.util.parse import make_problem_markdown
+from atcdr.util.parse import ProblemHTML
 
 
 def get_code_from_gpt_output(output: str) -> str:
@@ -65,7 +64,7 @@ def generate_code(file: Filename, lang: Lang) -> None:
     console = Console()
     with open(file, 'r') as f:
         html_content = f.read()
-    md = make_problem_markdown(html_content, 'en')
+    md = ProblemHTML(html_content).make_problem_markdown('en')
 
     if set_api_key() is None:
         return
@@ -96,7 +95,7 @@ def generate_template(file: Filename, lang: Lang) -> None:
     console = Console()
     with open(file, 'r') as f:
         html_content = f.read()
-    md = make_problem_markdown(html_content, 'en')
+    md = ProblemHTML(html_content).make_problem_markdown('en')
 
     if set_api_key() is None:
         return
@@ -131,9 +130,10 @@ You must not solve the problem. Please faithfully reproduce the variable names d
 def solve_problem(file: Filename, lang: Lang) -> None:
     console = Console()
     with open(file, 'r') as f:
-        html_content = f.read()
-    md = make_problem_markdown(html_content, 'en')
-    labeled_cases = create_testcases_from_html(html_content)
+        html = ProblemHTML(f.read())
+
+    md = html.make_problem_markdown('en')
+    labeled_cases = html.load_labeled_testcase()
 
     if set_api_key() is None:
         return

--- a/atcdr/markdown.py
+++ b/atcdr/markdown.py
@@ -5,14 +5,14 @@ from rich.markdown import Markdown
 
 from atcdr.util.execute import execute_files
 from atcdr.util.filetype import FILE_EXTENSIONS, Lang
-from atcdr.util.parse import make_problem_markdown
+from atcdr.util.parse import ProblemHTML
 
 
 def save_markdown(html_path: str, lang: str) -> None:
     console = Console()
     with open(html_path, 'r', encoding='utf-8') as f:
-        html = f.read()
-    md = make_problem_markdown(html, lang)
+        html = ProblemHTML(f.read())
+    md = html.make_problem_markdown(lang)
     file_without_ext = os.path.splitext(html_path)[0]
     md_path = file_without_ext + FILE_EXTENSIONS[Lang.MARKDOWN]
 

--- a/atcdr/open.py
+++ b/atcdr/open.py
@@ -4,7 +4,7 @@ from rich.console import Console
 
 from atcdr.util.filetype import Lang
 from atcdr.util.execute import execute_files
-from atcdr.util.parse import find_link_from_html
+from atcdr.util.parse import ProblemHTML
 
 
 def open_html(file: str) -> None:
@@ -21,7 +21,7 @@ def open_html(file: str) -> None:
         )
         return
 
-    url = find_link_from_html(html_content)
+    url = ProblemHTML(html_content).link
     if url:
         webbrowser.open_new_tab(url)
         console.print(

--- a/atcdr/util/parse.py
+++ b/atcdr/util/parse.py
@@ -1,26 +1,122 @@
 import re
-from enum import Enum
-from typing import Match, Optional
+from typing import List, Optional
 
 from bs4 import BeautifulSoup as bs
 from bs4 import Tag
-from markdownify import MarkdownConverter  # type: ignore
+from markdownify import MarkdownConverter
 
 
-def repair_html(html: str) -> str:
-    html = html.replace('//img.atcoder.jp', 'https://img.atcoder.jp')
-    html = html.replace(
-        '<meta http-equiv="Content-Language" content="en">',
-        '<meta http-equiv="Content-Language" content="ja">',
-    )
-    html = html.replace('LANG = "en"', 'LANG="ja"')
-    html = remove_unnecessary_emptylines(html)
-    return html
+class HTML:
+    def __init__(self, html: str) -> None:
+        self.soup = bs(html, 'html.parser')
+        self.title = self._get_title()
+        self.link = self._find_link()
+
+    def _get_title(self) -> str:
+        title_tag = self.soup.title
+        return title_tag.string.strip() if title_tag else ''
+
+    def _find_link(self) -> Optional[str]:
+        meta_tag = self.soup.find('meta', property='og:url')
+        if isinstance(meta_tag, Tag) and 'content' in meta_tag.attrs:
+            content = meta_tag['content']
+            if isinstance(content, list):
+                return content[0]  # 必要に応じて、最初の要素を返す
+            return content
+        return ''
+
+    @property
+    def html(self) -> str:
+        return str(self.soup)
+
+    def __str__(self) -> str:
+        return self.html
 
 
-def get_title_from_html(html: str) -> str:
-    title: Optional[Match[str]] = re.search(r'<title>([^<]*)</title>', html)
-    return title.group(1).strip() if title else ''
+class CustomMarkdownConverter(MarkdownConverter):
+    def convert_var(self, el, text, convert_as_inline):
+        var_text = el.text.strip()
+        return f'\\({var_text}\\)'
+
+    def convert_pre(self, el, text, convert_as_inline):
+        pre_text = el.text.strip()
+        return f'```\n{pre_text}\n```'
+
+
+class ProblemHTML(HTML):
+    def repair_me(self) -> None:
+        html = self.html.replace('//img.atcoder.jp', 'https://img.atcoder.jp')
+        html = html.replace(
+            '<meta http-equiv="Content-Language" content="en">',
+            '<meta http-equiv="Content-Language" content="ja">',
+        )
+        html = html.replace('LANG = "en"', 'LANG="ja"')
+        self.soup = bs(html, 'html.parser')
+
+    def abstract_problem_part(self, lang: str) -> Optional[Tag]:
+        task_statement = self.soup.find('div', {'id': 'task-statement'})
+        if not isinstance(task_statement, Tag):
+            return None
+
+        if lang == 'ja':
+            lang_class = 'lang-ja'
+        elif lang == 'en':
+            lang_class = 'lang-en'
+        else:
+            raise ValueError(f'言語は {lang} に対応していません')
+        span = task_statement.find('span', {'class': lang_class})
+        return span
+
+    def make_problem_markdown(self, lang: str) -> str:
+        title = self.title
+        problem_part = self.abstract_problem_part(lang)
+        if problem_part is None:
+            return ''
+
+        problem_md = CustomMarkdownConverter().convert(str(problem_part))
+        problem_md = f'# {title}\n{problem_md}'
+        problem_md = re.sub(r'\n\s*\n\s*\n+', '\n\n', problem_md).strip()
+        return problem_md
+
+    def load_labeled_testcase(self) -> List:
+        from atcdr.test import LabeledTestCase, TestCase
+
+        problem_part = self.abstract_problem_part('en')
+        if problem_part is None:
+            return []
+
+        sample_inputs = problem_part.find_all(
+            'h3', text=re.compile(r'Sample Input \d+')
+        )
+        ltest_cases = []
+        for i, sample_input_section in enumerate(sample_inputs, start=1):
+            # 対応する Sample Output を取得
+            sample_output_section = problem_part.find('h3', text=f'Sample Output {i}')
+            if not sample_input_section or not sample_output_section:
+                break
+
+            sample_input_pre = sample_input_section.find_next('pre')
+            sample_output_pre = sample_output_section.find_next('pre')
+
+            # 入力と出力をテキスト形式で取得
+            sample_input = (
+                sample_input_pre.get_text(strip=True)
+                if sample_input_pre is not None
+                else ''
+            )
+            sample_output = (
+                sample_output_pre.get_text(strip=True)
+                if sample_output_pre is not None
+                else ''
+            )
+
+            ltest_cases.append(
+                LabeledTestCase(
+                    f'Sample Case {i}', TestCase(sample_input, sample_output)
+                )
+            )
+
+        return ltest_cases
 
 
 def get_username_from_html(html: str) -> str:
@@ -40,81 +136,13 @@ def get_username_from_html(html: str) -> str:
     return user_screen_name
 
 
-def title_to_filename(title: str) -> str:
-    title = re.sub(r'[\\/*?:"<>| !@#$%^&()+=\[\]{};,\']', '', title)
-    title = re.sub(r'.*?-', '', title)
-    return title
-
-
-def find_link_from_html(html: str) -> str:
-    soup = bs(html, 'html.parser')
-    meta_tag = soup.find('meta', property='og:url')
-    if isinstance(meta_tag, Tag) and 'content' in meta_tag.attrs:
-        content = meta_tag['content']
-        if isinstance(content, list):
-            return content[0]  # 必要に応じて、最初の要素を返す
-        return content
-    return ''
-
-
-class Lang(Enum):
-    JA = 'ja'
-    EN = 'en'
-
-
-class CustomMarkdownConverter(MarkdownConverter):
-    def convert_var(self, el, text, convert_as_inline):
-        var_text = el.text.strip()
-        return f'\\({var_text}\\)'
-
-    def convert_pre(self, el, text, convert_as_inline):
-        pre_text = el.text.strip()
-        return f'```\n{pre_text}\n```'
-
-
-def custom_markdownify(html, **options):
-    return CustomMarkdownConverter(**options).convert(html)
-
-
-def remove_unnecessary_emptylines(text):
-    text = re.sub(r'\n\s*\n\s*\n+', '\n\n', text)
-    text = text.strip()
-    return text
-
-
-def abstract_problem_part(html_content: str, lang: str) -> str:
-    soup = bs(html_content, 'html.parser')
-    task_statement = soup.find('div', {'id': 'task-statement'})
-
-    if not isinstance(task_statement, Tag):
-        return ''
-
-    if lang == 'ja':
-        lang_class = 'lang-ja'
-    elif lang == 'en':
-        lang_class = 'lang-en'
-    else:
-        pass
-    span = task_statement.find('span', {'class': lang_class})
-    return str(span)
-
-
-def make_problem_markdown(html_content: str, lang: str) -> str:
-    title = get_title_from_html(html_content)
-    problem_part = abstract_problem_part(html_content, lang)
-    problem_md = custom_markdownify(problem_part)
-    problem_md = f'# {title}\n{problem_md}'
-    problem_md = remove_unnecessary_emptylines(problem_md)
-    return problem_md
-
-
 def get_csrf_token(html_content: str) -> str:
     soup = bs(html_content, 'html.parser')
     csrf_token = soup.find('input', {'name': 'csrf_token'})['value']
     return csrf_token if csrf_token else ''
 
 
-def get_problem_url_from_tasks(html_content: str) -> list[tuple[str, str]]:
+def get_problem_urls_from_tasks(html_content: str) -> list[tuple[str, str]]:
     soup = bs(html_content, 'html.parser')
     table = soup.find('table')
     if not table:

--- a/atcdr/util/problem.py
+++ b/atcdr/util/problem.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 import requests
 
-from atcdr.util.parse import get_problem_url_from_tasks
+from atcdr.util.parse import get_problem_urls_from_tasks
 
 
 class Contest:
@@ -43,7 +43,7 @@ class Contest:
 
         return [
             Problem(self, label=label, url=url)
-            for label, url in get_problem_url_from_tasks(response.text)
+            for label, url in get_problem_urls_from_tasks(response.text)
         ]
 
 


### PR DESCRIPTION
parseモジュールについてクラスでほとんどを書き直した。クラスに分類できないAtCoderの特定ページのparseについては関数で残っているから、再度整理する必要がまだある。また、このモジュールを使っているすべてのコマンドを修正した

bfef2f12cdf7ea0cc73ee7e478f9a6d115ec70ca