### PR TITLE
Feat/submit : submitコマンドの実装

### DIFF
--- a/atcdr/generate.py
+++ b/atcdr/generate.py
@@ -30,7 +30,7 @@ def render_result_for_GPT(
 ) -> tuple[str, bool]:
     results = list(test)
 
-    match test.info.results_summary:
+    match test.info.summary:
         case ResultStatus.AC:
             return 'Accepted', True
         case ResultStatus.CE:

--- a/atcdr/login.py
+++ b/atcdr/login.py
@@ -3,18 +3,21 @@ from rich.console import Console
 from rich.prompt import Prompt
 
 from atcdr.util.parse import get_csrf_token
-from atcdr.util.session import load_session, save_session, validate_session
+from atcdr.util.session import (
+    load_session,
+    save_session,
+    validate_session,
+)
 
 
-def login() -> bool:
+def login() -> None:
     ATCODER_LOGIN_URL = 'https://atcoder.jp/login'
     ATCODER_HOME_URL = 'https://atcoder.jp/home'
-
     console = Console()
     session = load_session()
     if validate_session(session):
         console.print('[green][+][/] すでにログイン済みです.  ')
-        return True
+        return
 
     username = Prompt.ask('[cyan]ユーザー名を入力してください[/]', console=console)
     password = Prompt.ask('[cyan]パスワードを入力してください[/]', console=console)
@@ -35,7 +38,5 @@ def login() -> bool:
     if login_response.url == ATCODER_HOME_URL and login_response.status_code == 200:
         console.print('[green][+][/] ログインに成功しました.  ')
         save_session(session)
-        return True
     else:
         console.print('[red][-][/] ログインに失敗しました.  ')
-        return False

--- a/atcdr/login.py
+++ b/atcdr/login.py
@@ -6,7 +6,7 @@ from atcdr.util.parse import get_csrf_token
 from atcdr.util.session import load_session, save_session, validate_session
 
 
-def login() -> None:
+def login() -> bool:
     ATCODER_LOGIN_URL = 'https://atcoder.jp/login'
     ATCODER_HOME_URL = 'https://atcoder.jp/home'
 
@@ -14,7 +14,7 @@ def login() -> None:
     session = load_session()
     if validate_session(session):
         console.print('[green][+][/] すでにログイン済みです.  ')
-        return
+        return True
 
     username = Prompt.ask('[cyan]ユーザー名を入力してください[/]', console=console)
     password = Prompt.ask('[cyan]パスワードを入力してください[/]', console=console)
@@ -35,5 +35,7 @@ def login() -> None:
     if login_response.url == ATCODER_HOME_URL and login_response.status_code == 200:
         console.print('[green][+][/] ログインに成功しました.  ')
         save_session(session)
+        return True
     else:
         console.print('[red][-][/] ログインに失敗しました.  ')
+        return False

--- a/atcdr/main.py
+++ b/atcdr/main.py
@@ -9,6 +9,7 @@ from atcdr.login import login
 from atcdr.logout import logout
 from atcdr.markdown import markdown
 from atcdr.open import open_files
+from atcdr.submit import submit
 from atcdr.test import test
 
 
@@ -30,6 +31,8 @@ MAP_COMMANDS: dict = {
     'md': markdown,
     'login': login,
     'logout': logout,
+    'submit': submit,
+    's': submit,
     '--version': get_version,
     '-v': get_version,
 }

--- a/atcdr/submit.py
+++ b/atcdr/submit.py
@@ -1,0 +1,14 @@
+from atcdr.util.execute import execute_files
+from atcdr.util.filetype import COMPILED_LANGUAGES, INTERPRETED_LANGUAGES
+
+
+def submit_source(path: str) -> None:
+    pass
+
+
+def submit(*args: str) -> None:
+    execute_files(
+        *args,
+        func=submit_source,
+        target_filetypes=COMPILED_LANGUAGES + INTERPRETED_LANGUAGES,
+    )

--- a/atcdr/submit.py
+++ b/atcdr/submit.py
@@ -219,7 +219,7 @@ def print_status_submission(
         live.update(create_renderable_test_info(test_info, progress))
 
 
-def submit_source(path: str) -> None:
+def submit_source(path: str, no_test: bool, no_feedback: bool) -> None:
     session = load_session()
     if not validate_session(session):
         print('[red][-][/] ログインしていません.')
@@ -245,7 +245,7 @@ def submit_source(path: str) -> None:
     list(test)
     print(create_renderable_test_info(test.info))
 
-    if test.info.summary != ResultStatus.AC:
+    if test.info.summary != ResultStatus.AC and not no_test:
         print('[red][-][/] サンプルケースが AC していないので提出できません')
         return
 
@@ -253,12 +253,13 @@ def submit_source(path: str) -> None:
     if api_status_link is None:
         return
 
-    print_status_submission(api_status_link, path, session)
+    if not no_feedback:
+        print_status_submission(api_status_link, path, session)
 
 
-def submit(*args: str) -> None:
+def submit(*args: str, no_test: bool = False, no_feedback: bool = False) -> None:
     execute_files(
         *args,
-        func=submit_source,
+        func=lambda path: submit_source(path, no_test, no_feedback),
         target_filetypes=COMPILED_LANGUAGES + INTERPRETED_LANGUAGES,
     )

--- a/atcdr/submit.py
+++ b/atcdr/submit.py
@@ -7,7 +7,7 @@ import requests
 from rich import print
 
 from atcdr.login import login
-from atcdr.test import ResultStatus, TestRunner, render_results
+from atcdr.test import ResultStatus, TestRunner, create_renderable_test_info
 from atcdr.util.execute import execute_files
 from atcdr.util.filetype import (
     COMPILED_LANGUAGES,
@@ -125,11 +125,13 @@ def submit_source(path: str) -> None:
 
     lcases = problem.load_labeled_testcase()
     url = problem.link
+
     test = TestRunner(path, lcases)
-    render_results(test)
+    list(test)
+    print(create_renderable_test_info(test.info))
 
     if test.info.results_summary != ResultStatus.AC:
-        print('[red][-][/]サンプルケースが AC していないので提出できません')
+        print('[red][-][/] サンプルケースが AC していないので提出できません')
         return
 
     post_source(path, url, session)

--- a/atcdr/submit.py
+++ b/atcdr/submit.py
@@ -1,53 +1,138 @@
 import os
+from dataclasses import dataclass
+from typing import Dict, List
 
+import questionary as q
 import requests
+from rich import print
 
-from atcdr.test import create_testcases_from_html, judge_code_from
+from atcdr.login import login
+from atcdr.test import ResultStatus, TestRunner, render_results
 from atcdr.util.execute import execute_files
 from atcdr.util.filetype import (
     COMPILED_LANGUAGES,
     INTERPRETED_LANGUAGES,
     Lang,
     detect_language,
+    lang2str,
+    str2lang,
 )
-from atcdr.util.parse import find_link_from_html
-from atcdr.util.session import load_session
+from atcdr.util.parse import ProblemHTML, get_csrf_token
+from atcdr.util.session import load_session, validate_session
 
 
-def post_source(source_path: str, task_url: str, session: requests.Session) -> None:
+@dataclass
+class LanguageOption:
+    id: int
+    display_name: str
+    lang: Lang
+
+
+def convert_options_to_langs(options: Dict[str, int]) -> List[LanguageOption]:
+    lang_options = []
+    for display_name, id_value in options.items():
+        lang_name = display_name.split()[
+            0
+        ].lower()  # 例えば,C++ 23 (Clang 16.0.6)から「c++」を取り出す
+        try:
+            lang = str2lang(lang_name)
+        except KeyError:
+            continue
+        lang_options.append(
+            LanguageOption(id=id_value, display_name=display_name, lang=lang)
+        )
+
+    return lang_options
+
+
+def choose_langid_interactively(lang_dict: dict, lang: Lang) -> int:
+    options = convert_options_to_langs(lang_dict)
+    options = [*filter(lambda option: option.lang == lang, options)]
+
+    langid = q.select(
+        message=f'以下の一覧から{lang2str(lang)}の実装/コンパイラーを選択してください',
+        qmark='',
+        pointer='❯❯❯',
+        choices=[
+            q.Choice(title=f'{option.display_name}', value=option.id)
+            for option in options
+        ],
+        instruction='\n 十字キーで移動,[enter]で実行',
+        style=q.Style(
+            [
+                ('question', 'fg:#2196F3 bold'),
+                ('answer', 'fg:#FFB300 bold'),
+                ('pointer', 'fg:#FFB300 bold'),
+                ('highlighted', 'fg:#FFB300 bold'),
+                ('selected', 'fg:#FFB300 bold'),
+            ]
+        ),
+    ).ask()
+
+    return langid
+
+
+def post_source(
+    source_path: str, url: str, session: requests.Session
+) -> requests.Response:
+    with open(source_path, 'r') as file:
+        source = file.read()
+
+    problem = ProblemHTML(session.get(url).text)
+
+    task_screen_name = problem.find_task_screen_name_from_form()
+    submit_url = problem.find_submit_link_from_form()
+    lang_dict = problem.get_languages_options_from_form()
+
+    csrf_token = get_csrf_token(problem.html)
+
     lang = detect_language(source_path)
-    print(f'{lang}')
-    pass
+    langid = choose_langid_interactively(lang_dict, lang)
+
+    post_data = {
+        'data.LanguageId': str(langid),
+        'data.TaskScreenName': task_screen_name,
+        'sourceCode': source,
+        'csrf_token': csrf_token,
+    }
+
+    response = session.post(submit_url, data=post_data)
+    if response.status_code != 200:
+        print(f'[red][Error{response.status_code}][/] 提出に失敗しました.')
+        print(response.text)
+
+    return response
 
 
 def submit_source(path: str) -> None:
     session = load_session()
+    if not validate_session(session):
+        print('[red][-][/] ログインしていません.')
+        login()
+        if not validate_session(session):
+            print('[red][-][/] ログインに失敗しました.')
+            return
 
-    html_files = [
-        file
-        for file in os.listdir('.')
-        if os.path.isfile(file) and os.path.splitext(file)[1] in [Lang.HTML]
-    ]
+    html_files = [file for file in os.listdir('.') if file.endswith('.html')]
     if not html_files:
         print(
-            '問題のファイルが見つかりません。\n問題のファイルが存在するディレクトリーに移動してから実行してください。'
+            '問題のファイルが見つかりません \n問題のファイルが存在するディレクトリーに移動してから実行してください'
         )
         return
 
     with open(html_files[0], 'r') as file:
-        html = file.read()
+        problem = ProblemHTML(file.read())
 
-    ltestcases = create_testcases_from_html(html)
-    results = judge_code_from(ltestcases, path)
+    lcases = problem.load_labeled_testcase()
+    url = problem.link
+    test = TestRunner(path, lcases)
+    render_results(test)
 
-    print(results)
-
-    task_url = find_link_from_html(html)
-    if not task_url:
-        print('URLを見つけられません。')
+    if test.info.results_summary != ResultStatus.AC:
+        print('[red][-][/]サンプルケースが AC していないので提出できません')
         return
 
-    post_source(path, task_url, session)
+    post_source(path, url, session)
 
 
 def submit(*args: str) -> None:

--- a/atcdr/submit.py
+++ b/atcdr/submit.py
@@ -80,9 +80,9 @@ def post_source(
 
     problem = ProblemHTML(session.get(url).text)
 
-    task_screen_name = problem.find_task_screen_name_from_form()
-    submit_url = problem.find_submit_link_from_form()
-    lang_dict = problem.get_languages_options_from_form()
+    task_screen_name = problem.form.find_task_screen_name()
+    submit_url = problem.form.find_submit_link()
+    lang_dict = problem.form.get_languages_options()
 
     csrf_token = get_csrf_token(problem.html)
 

--- a/atcdr/submit.py
+++ b/atcdr/submit.py
@@ -117,9 +117,11 @@ def post_source(source_path: str, url: str, session: requests.Session) -> Option
         return None
 
     submission_id = get_submission_id(response.text)
-    print(f'[green][+][/green] 提出に成功しました！提出ID: {submission_id}')
+    print('[green][+][/green] 提出に成功しました！')
+    url = response.url.replace('/me', f'/{submission_id}')
+    print(f'提出ID: {submission_id}, URL: {url}')
 
-    return response.url.replace('/me', f'/{submission_id}/status/json')
+    return url + '/status/json'
 
 
 class SubmissionStatus(NamedTuple):

--- a/atcdr/submit.py
+++ b/atcdr/submit.py
@@ -1,9 +1,53 @@
+import os
+
+import requests
+
+from atcdr.test import create_testcases_from_html, judge_code_from
 from atcdr.util.execute import execute_files
-from atcdr.util.filetype import COMPILED_LANGUAGES, INTERPRETED_LANGUAGES
+from atcdr.util.filetype import (
+    COMPILED_LANGUAGES,
+    INTERPRETED_LANGUAGES,
+    Lang,
+    detect_language,
+)
+from atcdr.util.parse import find_link_from_html
+from atcdr.util.session import load_session
+
+
+def post_source(source_path: str, task_url: str, session: requests.Session) -> None:
+    lang = detect_language(source_path)
+    print(f'{lang}')
+    pass
 
 
 def submit_source(path: str) -> None:
-    pass
+    session = load_session()
+
+    html_files = [
+        file
+        for file in os.listdir('.')
+        if os.path.isfile(file) and os.path.splitext(file)[1] in [Lang.HTML]
+    ]
+    if not html_files:
+        print(
+            '問題のファイルが見つかりません。\n問題のファイルが存在するディレクトリーに移動してから実行してください。'
+        )
+        return
+
+    with open(html_files[0], 'r') as file:
+        html = file.read()
+
+    ltestcases = create_testcases_from_html(html)
+    results = judge_code_from(ltestcases, path)
+
+    print(results)
+
+    task_url = find_link_from_html(html)
+    if not task_url:
+        print('URLを見つけられません。')
+        return
+
+    post_source(path, task_url, session)
 
 
 def submit(*args: str) -> None:

--- a/atcdr/util/parse.py
+++ b/atcdr/util/parse.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Optional
+from typing import Dict, Iterator, List, Optional
 
 from bs4 import BeautifulSoup as bs
 from bs4 import Tag
@@ -120,6 +120,29 @@ class ProblemHTML(HTML):
             )
 
         return ltest_cases
+
+    def find_submit_link_from_form(self) -> str:
+        form = self.soup.find('form', class_='form-code-submit')
+        action = form['action']
+        submit_url = f'https://atcoder.jp{action}'
+        return submit_url
+
+    def find_task_screen_name_from_form(self) -> str:
+        form = self.soup.find('form', class_='form-code-submit')
+        task_input = form.find('input', {'name': 'data.TaskScreenName'})
+        task_screen_name = task_input['value']
+        return task_screen_name
+
+    def get_languages_dict_from_form(self) -> Dict[str, int]:
+        form = self.soup.find('form', class_='form-code-submit')
+        options: Iterator[Tag] = form.find_all('option')
+
+        options = filter(
+            lambda option: 'value' in option.attrs and option['value'].isdigit(),
+            options,
+        )
+
+        return {option.text.strip(): int(option['value']) for option in options}
 
 
 def get_username_from_html(html: str) -> str:

--- a/atcdr/util/parse.py
+++ b/atcdr/util/parse.py
@@ -16,7 +16,7 @@ class HTML:
         title_tag = self.soup.title
         return title_tag.string.strip() if title_tag else ''
 
-    def _find_link(self) -> Optional[str]:
+    def _find_link(self) -> str:
         meta_tag = self.soup.find('meta', property='og:url')
         if isinstance(meta_tag, Tag) and 'content' in meta_tag.attrs:
             content = meta_tag['content']

--- a/atcdr/util/parse.py
+++ b/atcdr/util/parse.py
@@ -133,7 +133,7 @@ class ProblemHTML(HTML):
         task_screen_name = task_input['value']
         return task_screen_name
 
-    def get_languages_dict_from_form(self) -> Dict[str, int]:
+    def get_languages_options_from_form(self) -> Dict[str, int]:
         form = self.soup.find('form', class_='form-code-submit')
         options: Iterator[Tag] = form.find_all('option')
 

--- a/atcdr/util/parse.py
+++ b/atcdr/util/parse.py
@@ -196,3 +196,11 @@ def get_problem_urls_from_tasks(html_content: str) -> list[tuple[str, str]]:
             links.append((label, link))
 
     return links
+
+
+def get_submission_id(html_content: str) -> Optional[int]:
+    soup = bs(html_content, 'html.parser')
+    first_tr = soup.select_one('tbody > tr')
+    data_id_td = first_tr.find(lambda tag: tag.has_attr('data-id'))
+    data_id = int(data_id_td['data-id']) if data_id_td else None
+    return data_id

--- a/atcdr/util/session.py
+++ b/atcdr/util/session.py
@@ -35,6 +35,21 @@ def print_rich_response(
         header_table.add_row(key, value)
     header_table = Align.center(header_table)
 
+    # リダイレクトの歴史
+    redirect_table = None
+    if response.history:
+        redirect_table = Table(title='リダイレクト履歴')
+        redirect_table.add_column('ステップ', style='cyan')
+        redirect_table.add_column('ステータスコード', style='magenta')
+        redirect_table.add_column('URL', style='green')
+        for i, redirect_response in enumerate(response.history):
+            redirect_table.add_row(
+                f'Redirect {i}',
+                str(redirect_response.status_code),
+                redirect_response.url,
+            )
+        redirect_table = Align.center(redirect_table)
+
     # レスポンスボディの表示
     content_type = response.headers.get('Content-Type', '').lower()
     if 'application/json' in content_type:
@@ -60,6 +75,8 @@ def print_rich_response(
 
     print(info_table)
     print(header_table)
+    if redirect_table:
+        print(redirect_table)
     if body:
         print(body_panel)
 

--- a/atcdr/util/session.py
+++ b/atcdr/util/session.py
@@ -56,7 +56,14 @@ def print_rich_response(
     if 'application/json' in content_type:
         # JSONの整形表示
         try:
-            body = Syntax(response.json(), 'json', theme='monokai', line_numbers=True)
+            body = Syntax(
+                json.dumps(response.json(), indent=4),
+                'json',
+                theme='monokai',
+                line_numbers=True,
+                line_range=body_range,
+                word_wrap=True,
+            )
         except Exception:
             pass
     else:
@@ -68,6 +75,7 @@ def print_rich_response(
                 theme='monokai',
                 line_numbers=True,
                 line_range=body_range,
+                word_wrap=True,
             )
             if response.text
             else None

--- a/atcdr/util/session.py
+++ b/atcdr/util/session.py
@@ -14,6 +14,7 @@ from atcdr.util.parse import get_username_from_html
 COOKIE_PATH = os.path.join(os.path.expanduser('~'), '.cache', 'atcder', 'session.json')
 
 
+# デバック用のレスポンス解析用関数
 def print_rich_response(
     response: requests.Response, body_range: tuple = (0, 24)
 ) -> None:


### PR DESCRIPTION
submitコマンドを実装

・sessionからpostリクエストをAtCoderのサーバーに送ることで実装した。
・ソースコードの拡張子をみることで自動で言語を検出し、さらにAtcoderの提出のHTMLを解析して提出先のコンパイラーの候補を見つけてくれる。
・提出中のreqeustを1秒ごとに送り、ジャッジの進行状況を受け取れるようにした。